### PR TITLE
Fix navigation startDestination parameter typo

### DIFF
--- a/app/src/main/java/com/greenshark/quickattend/MainActivity.kt
+++ b/app/src/main/java/com/greenshark/quickattend/MainActivity.kt
@@ -61,7 +61,7 @@ class MainActivity : ComponentActivity() {
                     AppNavHost(
                         Modifier.padding(innerPadding),
                         navController = rememberNavController(),
-                        starDestination = if (authState == null) NavigationItem.Login.route else startDestination,
+                        startDestination = if (authState == null) NavigationItem.Login.route else startDestination,
                         authViewModel = authViewModel
                     )
                 }

--- a/app/src/main/java/com/greenshark/quickattend/ui/commons/AppNavHost.kt
+++ b/app/src/main/java/com/greenshark/quickattend/ui/commons/AppNavHost.kt
@@ -22,13 +22,13 @@ import com.greenshark.quickattend.ui.screens.WelcomeScreen
 fun AppNavHost(
     modifier: Modifier = Modifier,
     navController: NavHostController,
-    starDestination: String,
+    startDestination: String,
     authViewModel: AuthViewModel
 ) {
     NavHost(
         modifier = modifier,
         navController = navController,
-        startDestination = starDestination
+        startDestination = startDestination
     ) {
         composable(NavigationItem.Login.route) {
             LoginScreen(navController, authViewModel)


### PR DESCRIPTION
## Summary
- rename `starDestination` to `startDestination` in `AppNavHost`
- update call site in `MainActivity`

## Testing
- `./gradlew test` *(fails: Unable to download Gradle due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_688bd833ee80832a95fe0aa80ce0ec40